### PR TITLE
fix: task input default output 파싱

### DIFF
--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -21,6 +21,22 @@ def test_task_base():
     assert output == 'sprinklersprinklersprinkler'
 
 
+def test_parse_default_output():
+    def operation(b, a: str = 'hello') -> str:
+        return a * b
+
+    task = Task(
+        'test_parse_default_output',
+        operation,
+        {Task.DEFAULT_OUTPUT_KEY: 'sprinkler', 'b': 3}
+    )
+    context = Context()
+    task.execute(context)
+    output = context.retrieve({Task.DEFAULT_OUTPUT_KEY: ''})[Task.DEFAULT_OUTPUT_KEY]
+
+    assert output == 'sprinklersprinklersprinkler'
+
+
 def test_task_with_default():
     def operation(a: str, b: int = 3) -> str:
         return a * b
@@ -85,6 +101,22 @@ def test_task_with_output_config():
     output = context.retrieve({Task.DEFAULT_OUTPUT_KEY: ''})[Task.DEFAULT_OUTPUT_KEY]
 
     assert output == 'sprinklersprinklersprinkler'
+
+
+def test_type_error_with_none_input():
+    def operation(a: str, b: int = 3) -> str:
+        return a * b
+
+    task = Task(
+        'test_type_error_with_none_input',
+        operation,
+        {'a': None}
+    )
+    context = Context()
+    with pytest.raises(Exception) as err:
+        task.execute(context)
+
+    assert 'input' in err.value.args[0]
 
 
 def test_input_name_error():


### PR DESCRIPTION
### Issue
<!--Paste associated issue below-->
close #24

### Result
<!--Major consequence if you want to illustrate-->
이전 task output이 key-value pair가 아닌 경우에 매칭되지 못한 input이 딱 하나 있으면 해당 input에 매칭시키도록 로직을 수정하였습니다.

### Additional Info
<!--Supplementary information associated with this pull request-->