### PR TITLE
Feat/19

### DIFF
--- a/sprinkler/context/base.py
+++ b/sprinkler/context/base.py
@@ -55,16 +55,17 @@ class Context:
         return result
     
 
-    def replace_local_context(self, context: dict[str, Any]) -> None:
-        """Replace with new local values
-        
-        gurantees that previous values is removed
+    def set_local_context(self, context: dict[str, Any]) -> None:
+        """Set local context (before task begins)
 
         Args:
-            context: dictionary with {source}: {value}
+            context: dictionary with {source}: {value} 
         """
+        self.local_context.update(context)
+
+    def clear_local_context(self) -> None:
+        """Remove all values in local context (after task finished)"""
         self.local_context.clear()
-        self.local_context.update(context)   
     
     def add_global_context(self, context: dict[str, Any]) -> None:
         """Add some values to global context

--- a/sprinkler/context/base.py
+++ b/sprinkler/context/base.py
@@ -4,19 +4,107 @@ from typing import Any
 
 
 class Context:
+    """Context for task and pipline(process)
+    
+    Attributes:
+        local_context: context values for current task
+        output_context: context values for output of previous tasks
+        global_context: context values for being used in entire process
+        history_context: context values for recording context for specific task (monitoring)
+    """
+    
     def __init__(self) -> None:
-        self._context = {'local': {}, 'global': {}}
+        """Initializes all contexts to empty dictionary"""
+        self.local_context = {}
+        self.output_context = {} 
+        self.global_context = {} 
+        self.history_context = {}
 
-    def retrieve(self, query: dict[str, Any]) -> dict[str, Any]:
+    def get_values(self, query: dict[str, Any]) -> dict[str, Any]:
+        """Retrieve values in context requested by query
+
+        result doesn't include value which doesn't exist in context
+        priority: history(if task_id is specifed) -> local -> previous output -> global
+        
+        Args:
+            query: key-value pair with {argument_name}: {source}
+
+        Returns:
+            A dict mapping argument name to the correspoding value in the context
+            {argument_name}: {value}
+        """
         result = {}
-        for key in query:
-            value = self._context['local'].get(key) or self._context['global'].get(key)
-            if value is not None:
-                result[key] = value
+
+        for arg, src in query.items():
+            src_parts = src.split(sep='.', maxsplit=2)
+            value = None
+
+            if src_parts == 2:
+                task_id, arg = src_parts
+                if task_id in self.history_context:
+                    value = self.history_context[task_id].get(arg) 
+            else:
+                value = (
+                    self.local_context.get(src) 
+                    or self.output_context.get(src) 
+                    or self.global_context.get(src)
+                )
+
+            if value: result[arg] = value
+
         return result
     
-    def set(self, context: dict[str, Any], scope: str) -> None:
-        self._context[scope].update(context)
 
-    def delete_scope(self, scope: str) -> None:
-        self._context[scope].clear()
+    def replace_local_context(self, context: dict[str, Any]) -> None:
+        """Replace with new local values
+        
+        gurantees that previous values is removed
+
+        Args:
+            context: dictionary with {source}: {value}
+        """
+        self.local_context.clear()
+        self.local_context.update(context)   
+    
+    def add_global_context(self, context: dict[str, Any]) -> None:
+        """Add some values to global context
+        
+        Args:
+            context: dictionary with {source}: {value}
+        """
+        self.global_context.update(context)
+
+    def add_history_context(self, output: dict[str, Any], task_id: str) -> None:
+        """Record specific tasks's output to history context
+        
+        Args:
+            output: output of tasks. dictionary with {source}: {value} 
+            task_id: identifier of speicific task
+        """
+        if task_id in self.history_context:
+            raise Exception(f'{task_id} is already recorded in history context.')
+        self.history_context.update({task_id: output})
+
+    def replace_output_context(self, output: dict[str, Any]) -> None:
+        """Replace with tasks's output
+        
+        gurantees that previous output values is removed
+
+        Args:
+            context: dictionary with {source}: {value} 
+        """
+        self.output_context.clear()
+        self.output_context.update(output)
+
+    def __str__(self) -> str:
+        """Get all values from context
+
+        For debugging
+
+        Returns:
+            dictionary representation of all contexts
+        """
+        return (f'Local Context: {self.local_context}\n'
+                + f'Output Context: {self.output_context}\n'
+                + f'Global Context: {self.global_context}\n'
+                + f'History Context: {self.history_context}\n')

--- a/sprinkler/task/base.py
+++ b/sprinkler/task/base.py
@@ -118,7 +118,7 @@ class Task:
             context: The context of the pipeline.
 
         """
-        context.replace_local_context(self.context)
+        context.set_local_context(self.context)
         
         kwargs = self._parse_input(context)
 
@@ -126,6 +126,7 @@ class Task:
         output = self._parse_output(output)
 
         context.replace_output_context(output)
+        context.clear_local_context()
 
     
     def _parse_input(self, context: Context) -> dict[str, Any]:

--- a/sprinkler/task/base.py
+++ b/sprinkler/task/base.py
@@ -101,21 +101,19 @@ class Task:
         )
 
 
-
     def execute(self, context: Context) -> None:
-        context.set(self.context, 'local')
+        context.replace_local_context(self.context)
         
         args = self._parse_input(context)
 
         output = self.operation(**args)
         output = self._parse_output(output)
 
-        context.delete_scope('local')
-        context.set(output, 'local')
+        context.replace_output_context(output)
 
     
     def _parse_input(self, context: Context) -> dict[str, Any]:
-        args = context.retrieve(self.input_query)
+        args = context.get_values(self.input_query)
 
         try:
             self.input_model.model_validate(args)

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -16,7 +16,7 @@ def test_task_base():
     )
     context = Context()
     task.execute(context)
-    output = context.retrieve({Task.DEFAULT_OUTPUT_KEY: ''})[Task.DEFAULT_OUTPUT_KEY]
+    output = context.get_values({Task.DEFAULT_OUTPUT_KEY: Task.DEFAULT_OUTPUT_KEY})[Task.DEFAULT_OUTPUT_KEY]
 
     assert output == 'sprinklersprinklersprinkler'
 
@@ -32,7 +32,7 @@ def test_task_with_default():
     )
     context = Context()
     task.execute(context)
-    output = context.retrieve({Task.DEFAULT_OUTPUT_KEY: ''})[Task.DEFAULT_OUTPUT_KEY]
+    output = context.get_values({Task.DEFAULT_OUTPUT_KEY: Task.DEFAULT_OUTPUT_KEY})[Task.DEFAULT_OUTPUT_KEY]
 
     assert output == 'sprinklersprinklersprinkler'
 
@@ -48,7 +48,7 @@ def test_task_with_no_type_hint():
     )
     context = Context()
     task.execute(context)
-    output = context.retrieve({Task.DEFAULT_OUTPUT_KEY: ''})[Task.DEFAULT_OUTPUT_KEY]
+    output = context.get_values({Task.DEFAULT_OUTPUT_KEY: Task.DEFAULT_OUTPUT_KEY})[Task.DEFAULT_OUTPUT_KEY]
 
     assert output == 'sprinklersprinklersprinkler'
 
@@ -65,7 +65,7 @@ def test_task_with_input_config():
     )
     context = Context()
     task.execute(context)
-    output = context.retrieve({Task.DEFAULT_OUTPUT_KEY: ''})[Task.DEFAULT_OUTPUT_KEY]
+    output = context.get_values({Task.DEFAULT_OUTPUT_KEY: Task.DEFAULT_OUTPUT_KEY})[Task.DEFAULT_OUTPUT_KEY]
 
     assert output == 'sprinklersprinklersprinkler'
 
@@ -82,7 +82,7 @@ def test_task_with_output_config():
     )
     context = Context()
     task.execute(context)
-    output = context.retrieve({Task.DEFAULT_OUTPUT_KEY: ''})[Task.DEFAULT_OUTPUT_KEY]
+    output = context.get_values({Task.DEFAULT_OUTPUT_KEY: Task.DEFAULT_OUTPUT_KEY})[Task.DEFAULT_OUTPUT_KEY]
 
     assert output == 'sprinklersprinklersprinkler'
 


### PR DESCRIPTION
### Issue
<!--Paste associated issue below-->

https://github.com/KimJS0328/sprinkler/issues/19

### Result
<!--Major consequence if you want to illustrate-->

Context 는 `Local Context`: 현재 Task에 필요한 정보를 담아놓는 용도
`Output Context`: 이전 Output의 결과를 담아놓는 용도
`Global Context`: 태스크 및 파이프라인 전체에서 쓸 정보를 담아놓는 용도
`History Context`: 특정 태스크에 대한 Output을 담아놓는 용도 - 다른 태스크에 사용 및 추후 모니터링 용도

> 특정 Task가 종료된 시점에는 Output Context는 Update 되고 Local Context가 비워져야 하기에 `execute` 함수를 수정하였습니다.

### Additional Info
<!--Supplementary information associated with this pull request-->