### PR TITLE
feature: task decorator

### DIFF
--- a/sprinkler/task/decorator.py
+++ b/sprinkler/task/decorator.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from typing import Any
+
+from sprinkler import task
+
+class Task:
+    def __init__(
+        self,
+        id_: str,
+        *,
+        input_config: dict[str, Any | dict[str, Any]] | None = None,
+        output_config: type | None = None,
+    ) -> None:
+        self.id = id_
+        self.input_config = input_config
+        self.output_config = output_config
+
+    def __call__(self, func):
+        return task.Task(
+            self.id,
+            func,
+            input_config=self.input_config,
+            output_config=self.output_config
+        )

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -170,3 +170,19 @@ def test_instance_method():
     output = task(5)
 
     assert output == 25
+
+
+def test_with_decorator():
+    from sprinkler.task.decorator import Task
+    @Task(
+        'add', 
+        input_config={'a': int, 'b': int}, 
+        output_config=int
+    )
+    def add(a, b):
+        return a + b
+    
+    task = add
+    output = task(5, 5)
+
+    assert output == 10


### PR DESCRIPTION
### Issue
<!--Paste associated issue below-->

#28 

### Result
<!--Major consequence if you want to illustrate-->

함수 선언 시 아래와 같이 데코레이터 `Task` 로
`id, input_config(optional), output_config(optional)` 을 명시한다면

```python
from sprinkler.task.decorator import Tas
@Task(
    'task_add', 
    input_config={'a': int, 'b': int}, 
    output_config=int
)
def add(a, b):
    return a + b
```

아래와 같이 함수 자체가 새로운 `Task` 객체의 인스턴스가 됩니다.
    
```python
task = add
```

**⭐️ 따라서, 파이프라인에 task를 추가할 때 함수를 그냥 넣어주면 되는 효과가 있습니다.**

### Additional Info
<!--Supplementary information associated with this pull request-->