### PR TITLE
Feat/36 pipeline interface

### DIFF
--- a/sprinkler/context/base.py
+++ b/sprinkler/context/base.py
@@ -1,8 +1,6 @@
 from __future__ import annotations
 
-from enum import Enum
-
-from typing import Dict, Tuple, Any
+from typing import Any
 
 
 class Context:
@@ -14,15 +12,16 @@ class Context:
         history_context: context values for recording context for specific task (monitoring)
     """
 
-    global_context: Dict
-    history_context: Dict
+    global_context: dict
+    history_context: dict
     
     def __init__(self) -> None:
         """Initializes all contexts to empty dictionary"""
         self.global_context = {} 
         self.history_context = {}
 
-    def get_kwargs(self, query: dict[str, Any]) -> Tuple[Tuple, Dict[str, Any]]:
+
+    def get_kwargs(self, query: list[tuple[str, str]]) -> dict[str, Any]:
         """Retrieve arguments in context requested by query
 
         result doesn't include value which doesn't exist in context
@@ -36,7 +35,7 @@ class Context:
         """
         kwargs = {}
 
-        for arg, src in query.items():
+        for arg, src in query:
             # match argument with history context
             if src in self.history_context:
                 kwargs[arg] = self.history_context[src]
@@ -58,6 +57,7 @@ class Context:
             raise TypeError(f'Given context must be dictionary.')
         self.global_context.update(context)
 
+
     def add_history(self, output: Any, task_id: str) -> None:
         """Record specific tasks's output to history context
         
@@ -69,13 +69,6 @@ class Context:
             raise Exception(f'{task_id} is already recorded in history context.')
         self.history_context.update({task_id: output})
 
-    def replace_output(self, output: Any) -> None:
-        """Replace with tasks's output"""
-        self.output = output
-
-    def get_output(self) -> Any:
-        """Retrive output of current context"""
-        return self.output
 
     def __str__(self) -> str:
         """Get all values from context

--- a/sprinkler/pipeline/base.py
+++ b/sprinkler/pipeline/base.py
@@ -16,7 +16,7 @@ class Pipeline:
         context: the global context values for pipeline instance
     """
 
-    def __init__(self, id_: str, context: dict[str, Any] = None) -> None:
+    def __init__(self, id_: str, context: dict[str, Any] | None = None) -> None:
         """Initializes the pipeline instance with context
 
         Args:

--- a/sprinkler/task/base.py
+++ b/sprinkler/task/base.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Callable, Any
+from typing import Callable, Any, get_type_hints
 import inspect
 
 from pydantic import create_model, BaseModel, ValidationError
@@ -58,9 +58,9 @@ def _create_output_config(
     """
     
     """
-    annotations_ = inspect.getfullargspec(operation).annotations
+    annotations_ = get_type_hints(operation)
 
-    if user_config is not NotGiven:
+    if user_config is not None:
         output_type = user_config
 
     elif 'return' in annotations_:
@@ -69,18 +69,11 @@ def _create_output_config(
     else:
         output_type = Any
 
-    if output_type is None:
-        output_type = type(None)
-
     return {
         config.DEFAULT_OUTPUT_KEY: {
             'type': output_type
         }
     }
-
-
-class NotGiven:
-    ...
 
 
 class Task:
@@ -97,8 +90,8 @@ class Task:
         id_: str,
         operation: Callable,
         *,
-        input_config: dict[str, Any | dict[str, Any]] = None,
-        output_config: dict[str, Any] | Any = NotGiven,
+        input_config: dict[str, Any | dict[str, Any]] | None = None,
+        output_config: dict[str, Any] | Any | None = None,
     ) -> None:
         """Initialize the task class.
 

--- a/sprinkler/task/decorator.py
+++ b/sprinkler/task/decorator.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import Any
 
 from sprinkler import task
-from sprinkler.task.base import NotGiven
+
 
 class Task:
     def __init__(
@@ -11,7 +11,7 @@ class Task:
         id_: str,
         *,
         input_config: dict[str, Any | dict[str, Any]] | None = None,
-        output_config: type | None = NotGiven,
+        output_config: type | None = None,
     ) -> None:
         self.id = id_
         self.input_config = input_config

--- a/test.py
+++ b/test.py
@@ -1,13 +1,15 @@
-from __future__ import annotations
 
-from typing import Any, List
+class A:
+    def a(self, b: int) -> None:
+        print()
 
-from pydantic import BaseModel
+from inspect import Signature
 
+sig = Signature.from_callable(A().a)
 
-class Model(BaseModel):
-    a: List[int]
-    b: Any
+print(bool(sig.parameters['b'].annotation))
+print(sig.parameters['b'].default)
+print(sig.return_annotation)
 
-
-print(Model(a=('1', 2, 3), b='ok'))
+from typing import get_type_hints
+print(get_type_hints(A().a))

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -20,12 +20,13 @@ def test_pipeline_base():
         operation2
     )
 
-    p = Pipeline()
+    p = Pipeline('test_pipeline_base')
     p.add_task(task1)
     p.add_task(task2)
     output = p.run(3, 2)
 
     assert output == 729
+
 
 def test_pipeline_with_args():
     def operation1(a, b):
@@ -46,12 +47,13 @@ def test_pipeline_with_args():
         operation2
     )
 
-    p = Pipeline()
+    p = Pipeline('test_pipeline_with_args')
     p.add_task(task1)
     p.add_task(task2)
     output = p.run(5, 6)
 
     assert output == 270
+
 
 def test_pipeline_with_history():
     def operation1(a, b):
@@ -80,11 +82,48 @@ def test_pipeline_with_history():
         {'a': {'src': 'task1'}}
     )
 
-    p = Pipeline()
+    p = Pipeline('test_pipeline_with_history')
     p.add_task(task1)
     p.add_task(task2)
     p.add_task(task3)
 
     output = p.run(2, 10)
+
+    assert output == 25
+
+
+def test_pipeline_with_context():
+    def operation1(a, b):
+        return a * b
+
+    def operation2():
+        pass
+
+    def operation3(a):
+        return a + 5
+
+    task1 = Task(
+        'task1',
+        operation1
+    )
+
+    task2 = Task(
+        'task2',
+        operation2,
+        output_config=None
+    )
+
+    task3 = Task(
+        'task3',
+        operation3,
+        {'a': {'src': 'task1'}}
+    )
+
+    p = Pipeline('test_pipeline_with_context', {'b': 10})
+    p.add_task(task1)
+    p.add_task(task2)
+    p.add_task(task3)
+
+    output = p.run(2)
 
     assert output == 25

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -147,7 +147,7 @@ def test_input_name_error():
     with pytest.raises(Exception) as err:
         output = task.run('sprinkler', c=3)
 
-    assert 'unexpected' in err.value.args[0]
+    assert 'missing' in err.value.args[0]
 
 
 def test_input_type_error():


### PR DESCRIPTION
### Issue
<!--Paste associated issue below-->
#36

### Result
<!--Major consequence if you want to illustrate-->
- `Pipeline`과 `Task`의 실행과 관련된 인터페이스를 `run`으로 통일하고 `Context` 객체 대신 실행 인자를 받게 변경되었습니다. 
- `Pipeline`에서 input argument의 binding을 관리하며 `Task`는 이에 대해 알지 못합니다.
- `Pipeline`의 `output_config`를 NoneType으로 설정하고 싶으면 type hint를 None으로 하거나, `output_config=type(None)`으로 하도록 수정하였습니다.

### Additional Info
<!--Supplementary information associated with this pull request-->
- pydantic이 `typing.get_type_hints`를 사용하는데 해당 함수는 `from __future__ import annotations`가 통하지 않습니다... 그래서 typing 모듈을 통하지 않고 `list[int]` 등을 쓰면 동작하지 않습니다.